### PR TITLE
made compatible with latest mxnet

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ addons:
       sources:
         - ubuntu-toolchain-r-test
       packages:
-        - clang
+        - clang-3.5
         - g++
         - build-essential
         - libopencv-dev
@@ -18,6 +18,7 @@ addons:
     
 before_install:
     - source travis/env.sh
+    - sudo apt-get update
 
 install:
     # dep

--- a/examples/batch/batch.go
+++ b/examples/batch/batch.go
@@ -138,7 +138,8 @@ func main() {
 			}()
 		}
 	}
-	// Changed interface
+
+	// define profiling options
         poptions := map[string]mxnet.ProfileMode{
                 "profile_all": mxnet.ProfileAllEnable,
                 "profile_symbolic": mxnet.ProfileSymbolicOperatorsEnable,

--- a/examples/batch/batch.go
+++ b/examples/batch/batch.go
@@ -138,8 +138,17 @@ func main() {
 			}()
 		}
 	}
-
-	if profile, err := mxnet.NewProfile(mxnet.ProfileAllOperators, ""); err == nil {
+	// Changed interface
+        poptions := map[string]mxnet.ProfileMode{
+                "profile_all": mxnet.ProfileAllEnable,
+                "profile_symbolic": mxnet.ProfileSymbolicOperatorsEnable,
+                "profile_imperative": mxnet.ProfileImperativeOperatorsEnable,
+                "profile_memory": mxnet.ProfileMemoryDisable,
+                "profile_api": mxnet.ProfileApiDisable,
+                "contiguous_dump": mxnet.ProfileContiguousDumpDisable,
+                "dump_period": mxnet.ProfileDumpPeriod,
+        }
+	if profile, err := mxnet.NewProfile(poptions, ""); err == nil {
 		profile.Start()
 
 		defer func() {

--- a/examples/single/single.go
+++ b/examples/single/single.go
@@ -117,7 +117,17 @@ func main() {
 		}
 	}
 
-	if profile, err := mxnet.NewProfile(mxnet.ProfileAllOperators, ""); err == nil {
+	// define profiling optionse
+        poptions := map[string]mxnet.ProfileMode{
+                "profile_all": mxnet.ProfileAllDisable,
+                "profile_symbolic": mxnet.ProfileSymbolicOperatorsEnable,
+                "profile_imperative": mxnet.ProfileImperativeOperatorsDisable,
+                "profile_memory": mxnet.ProfileMemoryDisable,
+                "profile_api": mxnet.ProfileApiDisable,
+                "contiguous_dump": mxnet.ProfileContiguousDumpDisable,
+                "dump_period": mxnet.ProfileDumpPeriod,
+        }
+	if profile, err := mxnet.NewProfile(poptions, ""); err == nil {
 		profile.Start()
 
 		defer func() {

--- a/examples/single/single.go
+++ b/examples/single/single.go
@@ -117,7 +117,7 @@ func main() {
 		}
 	}
 
-	// define profiling optionse
+	// define profiling options
         poptions := map[string]mxnet.ProfileMode{
                 "profile_all": mxnet.ProfileAllDisable,
                 "profile_symbolic": mxnet.ProfileSymbolicOperatorsEnable,

--- a/mxnet/lib.go
+++ b/mxnet/lib.go
@@ -1,7 +1,7 @@
 package mxnet
 
-// #cgo CFLAGS: -I/opt/mxnet/include
-// #cgo LDFLAGS: -L/opt/mxnet/lib -lmxnet
-// #cgo linux CFLAGS: -I /home/carml/frameworks/mxnet/include -I /opt/mxnet/include  -I /opt/frameworks/mxnet/include
-// #cgo linux LDFLAGS: -L /home/carml/frameworks/mxnet/lib -L /opt/mxnet/lib -L /opt/frameworks/mxnet/lib -lmxnet
+// #cgo CFLAGS: -I/home/as29/my_mxnet/apache-mxnet-src-1.2.0-incubating/include
+// #cgo LDFLAGS: -L/home/as29/my_mxnet/apache-mxnet-src-1.2.0-incubating/lib -lmxnet
+// #cgo linux CFLAGS: -I /home/as29/my_mxnet/apache-mxnet-src-1.2.0-incubating/include
+// #cgo linux LDFLAGS: -L /home/as29/my_mxnet/apache-mxnet-src-1.2.0-incubating/lib -lmxnet
 import "C"

--- a/mxnet/profile.go
+++ b/mxnet/profile.go
@@ -76,6 +76,7 @@ func NewProfile(profileOptions map[string]ProfileMode, tmpDir string) (*Profile,
         }
 
         cs := C.CString(filename)
+	defer C.free(unsafe.Pointer(cs))
         keys := [8]string{"filename", "profile_all", "profile_symbolic", "profile_imperative", "profile_memory","profile_api", "contiguous_dump", "dump_period"}
 
         // convert go data structures into c data structures
@@ -99,7 +100,6 @@ func NewProfile(profileOptions map[string]ProfileMode, tmpDir string) (*Profile,
         }
 
         // free C pointers
-        C.free(unsafe.Pointer(cs))
 	C.free(unsafe.Pointer(ckeys))
         C.free(unsafe.Pointer(cvals))
 

--- a/mxnet/profile.go
+++ b/mxnet/profile.go
@@ -38,8 +38,9 @@ type Profile struct {
 	filename  string
 }
 
+// profile type
 type ProfileMode string
-
+// profile options
 const (
         ProfileAllDisable = ProfileMode(0)
         ProfileSymbolicOperatorsDisable = ProfileMode(0)
@@ -62,7 +63,7 @@ const (
 // CHANGE: modified interface to support new profiling options
 // TODO: make conversion neater if possible
 // TODO: check functionality
-func NewProfile(profile_options map[string]ProfileMode, tmpDir string) (*Profile, error) {
+func NewProfile(profileOptions map[string]ProfileMode, tmpDir string) (*Profile, error) {
         if tmpDir == "" {
                 tmpDir = filepath.Join(config.App.TempDir, "mxnet", "profile")
         }
@@ -86,7 +87,7 @@ func NewProfile(profile_options map[string]ProfileMode, tmpDir string) (*Profile
         b[0] = cs
         for i:= 1 ; i < 8 ; i++ {
                 a[i] = C.CString(keys[i])
-                b[i] = C.CString(string(profile_options[keys[i]]))
+                b[i] = C.CString(string(profileOptions[keys[i]]))
         }
 
         success, err := C.MXSetProfilerConfig(C.int(len(keys)), (**C.char)(ckeys), (**C.char)(cvals))
@@ -164,7 +165,7 @@ func (p *Profile) Dump(finished bool) (string, error) {
 	defer func() {
 		p.dumped = true
 	}()
-	var fin int = 0
+	var fin int
 	if finished {
 		fin = 1
 	}

--- a/mxnet/profile.go
+++ b/mxnet/profile.go
@@ -60,9 +60,6 @@ const (
 // go binding for MXSetProfilerConfig()
 // param profile_options map of profiling options
 // param tmpDir output filepath
-// CHANGE: modified interface to support new profiling options
-// TODO: make conversion neater if possible
-// TODO: check functionality
 func NewProfile(profileOptions map[string]ProfileMode, tmpDir string) (*Profile, error) {
         if tmpDir == "" {
                 tmpDir = filepath.Join(config.App.TempDir, "mxnet", "profile")
@@ -151,7 +148,6 @@ func (p *Profile) Stop() error {
 }
 
 // go binding for MXDumpProfile()
-// CHANGE: passing bool arg to MXDumpProfile()
 func (p *Profile) Dump(finished bool) (string, error) {
 	if !p.started {
 		return "", errors.New("mxnet profile was not started")

--- a/mxnet/profile.go
+++ b/mxnet/profile.go
@@ -38,44 +38,77 @@ type Profile struct {
 	filename  string
 }
 
-type ProfileMode int
+type ProfileMode string
 
 const (
-	ProfileSymbolicOperators = ProfileMode(0)
-	ProfileAllOperators      = ProfileMode(1)
+        ProfileAllDisable = ProfileMode(0)
+        ProfileSymbolicOperatorsDisable = ProfileMode(0)
+        ProfileImperativeOperatorsDisable = ProfileMode(0)
+        ProfileMemoryDisable = ProfileMode(0)
+        ProfileApiDisable = ProfileMode(0)
+        ProfileContiguousDumpDisable = ProfileMode(0)
+        ProfileAllEnable  = ProfileMode(1)
+        ProfileSymbolicOperatorsEnable = ProfileMode(1)
+        ProfileImperativeOperatorsEnable = ProfileMode(1)
+        ProfileMemoryEnable = ProfileMode(1)
+        ProfileApiEnable = ProfileMode(1)
+        ProfileContiguousDumpEnable = ProfileMode(1)
+        ProfileDumpPeriod = ProfileMode(1)
 )
 
 // go binding for MXSetProfilerConfig()
-// param mode kOnlySymbolic: 0, kAllOperator: 1
-// param filename output filename
-func NewProfile(mode ProfileMode, tmpDir string) (*Profile, error) {
-	if tmpDir == "" {
-		tmpDir = filepath.Join(config.App.TempDir, "mxnet", "profile")
-	}
-	if !com.IsDir(tmpDir) {
-		os.MkdirAll(tmpDir, os.FileMode(0755))
-	}
-	filename, err := tempFile(tmpDir, "profile-", ".json")
-	if err != nil {
-		return nil, errors.Errorf("cannot create temporary file in %v", tmpDir)
-	}
+// param profile_options map of profiling options
+// param tmpDir output filepath
+// CHANGE: modified interface to support new profiling options
+// TODO: make conversion neater if possible
+// TODO: check functionality
+func NewProfile(profile_options map[string]ProfileMode, tmpDir string) (*Profile, error) {
+        if tmpDir == "" {
+                tmpDir = filepath.Join(config.App.TempDir, "mxnet", "profile")
+        }
+        if !com.IsDir(tmpDir) {
+                os.MkdirAll(tmpDir, os.FileMode(0755))
+        }
+        filename, err := tempFile(tmpDir, "profile-", ".json")
+        if err != nil {
+                return nil, errors.Errorf("cannot create temporary file in %v", tmpDir)
+        }
 
-	cs := C.CString(filename)
-	defer C.free(unsafe.Pointer(cs))
-	success, err := C.MXSetProfilerConfig(C.int(mode), cs)
-	if err != nil {
-		return nil, err
-	}
-	if success != 0 {
-		return nil, GetLastError()
-	}
+        cs := C.CString(filename)
+        keys := [8]string{"filename", "profile_all", "profile_symbolic", "profile_imperative", "profile_memory","profile_api", "contiguous_dump", "dump_period"}
 
-	return &Profile{
-		Trace:    nil,
-		filename: filename,
-		stopped:  false,
-		dumped:   false,
-	}, nil
+        // convert go data structures into c data structures
+        ckeys := C.malloc(C.size_t(8) * C.size_t(unsafe.Sizeof(uintptr(0))))
+        a := (*[1<<30 - 1]*C.char)(ckeys)
+        cvals := C.malloc(C.size_t(8) * C.size_t(unsafe.Sizeof(uintptr(0))))
+        b := (*[1<<30 - 1]*C.char)(cvals)
+        a[0] = C.CString("filename")
+        b[0] = cs
+        for i:= 1 ; i < 8 ; i++ {
+                a[i] = C.CString(keys[i])
+                b[i] = C.CString(string(profile_options[keys[i]]))
+        }
+
+        success, err := C.MXSetProfilerConfig(C.int(len(keys)), (**C.char)(ckeys), (**C.char)(cvals))
+        if err != nil {
+                return nil, err
+        }
+        if success != 0 {
+                return nil, GetLastError()
+        }
+
+        // free C pointers
+        C.free(unsafe.Pointer(cs))
+	C.free(unsafe.Pointer(ckeys))
+        C.free(unsafe.Pointer(cvals))
+
+        return &Profile{
+                Trace:    nil,
+                filename: filename,
+                stopped:  false,
+                dumped:   false,
+        }, nil
+
 }
 
 // go binding for MXSetProfilerState(1)
@@ -117,7 +150,8 @@ func (p *Profile) Stop() error {
 }
 
 // go binding for MXDumpProfile()
-func (p *Profile) Dump() (string, error) {
+// CHANGE: passing bool arg to MXDumpProfile()
+func (p *Profile) Dump(finished bool) (string, error) {
 	if !p.started {
 		return "", errors.New("mxnet profile was not started")
 	}
@@ -130,8 +164,11 @@ func (p *Profile) Dump() (string, error) {
 	defer func() {
 		p.dumped = true
 	}()
-
-	success, err := C.MXDumpProfile()
+	var fin int = 0
+	if finished {
+		fin = 1
+	}
+	success, err := C.MXDumpProfile(C.int(fin))
 	if err != nil {
 		return "", err
 	}
@@ -170,7 +207,7 @@ func (p *Profile) Read() error {
 		}
 	}
 	if !p.dumped {
-		if _, err := p.Dump(); err != nil {
+		if _, err := p.Dump(true); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Have modified two profiling methods to make it compatible with the interface used in the latest mxnet release. Built successfully, ran <examples/single/single.go> successfully after making it coherent with the new profiling method interface. If changes confirmed, would have to alter its usage in other examples before merging.