### PR TITLE
updated to mxnet-1.2.0

### DIFF
--- a/dockerfiles/Makefile
+++ b/dockerfiles/Makefile
@@ -53,7 +53,7 @@ BUILD_ARGS = --build-arg BUILD_DATE=`date -u +"%Y-%m-%dT%H:%M:%SZ"` \
 			 --build-arg VCS_URL=`git config --get remote.origin.url` \
 		     --build-arg VCS_REF=$(GIT_COMMIT) \
 		     --build-arg ARCH=$(ARCH) \
-			 --build-arg FRAMEWORK_VERSION="0.11.0"
+			 --build-arg FRAMEWORK_VERSION="1.2.0"
 
 docker_build_gpu: # Build GPU Docker image
 	@docker build $(BUILD_ARGS) \


### PR DESCRIPTION
updated mxnet to latest release, is compatible with cuda-8.0 and cudnn 6.0...need to verify compatibility with cuda-9.0 and cudnn 7.0 once image pushed to registry. If it is not compatible, we can revert back to earlier docker image.